### PR TITLE
Create Warden's ENV file before writing encryption key

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -53,13 +53,15 @@ curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compos
 chmod a+x /usr/bin/docker-compose
 
 mkdir env
+envfile="env/warden"
+touch "${envfile}"
 
 addLine2File "WARDEN_ENCRYPTION_KEY=" "WARDEN_ENCRYPTION_KEY=${enckey}" "${envfile}"
 
 printf "Would you like to start the local postgres image? [y|N] "
 read custompg
 
-envfile="env/warden"
+
 if [ "${custompg}" == "y" ]
 then
     pghost="postgres"


### PR DESCRIPTION
Adding the encryption key to the file didn't work because the ENV file didn't exist yet. This led to errors later during dependency installation, which in turn led to errors when running the PDS. 

This fix creates the ENV file before trying to add the encryption key.