### PR TITLE
Splitting out localdb and fixing some bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,9 @@ start:
 
 upgrade:
 	@./upgrade.sh
+
+dbinstall:
+	@./localdb_install.sh
+
+dbstart:
+	@./localdb_start.sh

--- a/localdb_install.sh
+++ b/localdb_install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -e
+
+addUpdateLine2File() {
+    if [[ $# -eq 3 ]]; then
+        condition=$1
+        line=$2
+        file=$3
+    else
+        echo "Invalid number of arguments to addUpdateLine2File"
+        exit 1
+    fi
+
+    if ! grep -qF "$condition" "$file"; then
+        echo "Adding '$line' to $file"
+        echo "$line" >> "$file"
+    else
+        echo "'$condition' already exists in $file. Replacing it instead"
+        sed -i "s|${condition}.*|$line|" $file
+    fi
+}
+
+wardenfile="env/warden"
+clorthofile="env/clortho"
+
+if [[ -f $wardenfile ]]; then
+  echo "${wardenfile} already exists. Chickening out. Move the file and rerun this script if you want to run postgres locally."
+  exit 1
+fi
+
+if [[ -f $clorthofile ]]; then
+  echo "${clorthofile} already exists. Chickening out. Move the file and rerun this script if you want to run postgres locally."
+  exit 1
+fi
+
+pghost="warden_postgres"
+pgport=5432
+pgdatabase="warden"
+pguser="warden"
+pgpassword="wardenDBpass"
+
+addUpdateLine2File "PGHOST=" "PGHOST=${pghost}" "${wardenfile}"
+addUpdateLine2File "PGPORT=" "PGPORT=${pgport}" "${wardenfile}"
+addUpdateLine2File "PGDATABASE=" "PGDATABASE=${pgdatabase}" "${wardenfile}"
+addUpdateLine2File "PGUSER=" "PGUSER=${pguser}" "${wardenfile}"
+addUpdateLine2File "PGPASSWORD=" "PGPASSWORD=${pgpassword}" "${wardenfile}"
+
+pghost="clortho_postgres"
+pgport=6543
+pgdatabase="clortho"
+pguser="clortho"
+pgpassword="clorthoDBpass"
+
+addUpdateLine2File "PGHOST=" "PGHOST=${pghost}" "${clorthofile}"
+addUpdateLine2File "PGPORT=" "PGPORT=${pgport}" "${clorthofile}"
+addUpdateLine2File "PGDATABASE=" "PGDATABASE=${pgdatabase}" "${clorthofile}"
+addUpdateLine2File "PGUSER=" "PGUSER=${pguser}" "${clorthofile}"
+addUpdateLine2File "PGPASSWORD=" "PGPASSWORD=${pgpassword}" "${clorthofile}"

--- a/localdb_start.sh
+++ b/localdb_start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+source env/warden
+docker-compose -f docker-compose-dbs.yml up -d
+
+while ! ./ready.sh env/warden warden_postgres
+do
+  sleep 2
+done
+
+source env/clortho
+
+while ! ./ready.sh env/clortho clortho_postgres
+do
+  sleep 2
+done

--- a/ready.sh
+++ b/ready.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm --network skuid_pds --env-file $1 -it postgres:9.6 pg_isready
+docker run --rm --network skuid_pds --env-file $1 -e PGPORT=5432 -it postgres:9.6 pg_isready

--- a/start.sh
+++ b/start.sh
@@ -1,27 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-printf "Would you like to start the local postgres images? [y|N] "
-read startpg
-
-if [ "${startpg}" == "y" ]
-then
-  source env/warden
-  docker-compose -f docker-compose-dbs.yml up -d
-
-  while ! ./ready.sh env/warden warden_postgres
-  do
-    sleep 5
-  done
-
-  source env/clortho
-
-  while ! ./ready.sh env/clortho clortho_postgres
-  do
-    sleep 5
-  done
-fi
-
 docker-compose up -d redis seaquill
 
 ## We want to fail first trying to install the uuid extension, otherwise we get dirty migrations


### PR DESCRIPTION
- Splitting out the local database as a more "advanced" feature.
- better handling for when they already have and env file
- no longer stomping the encryption key if that file already exists in all cases
- fixed `ready.sh` to use 5432 always (since that'll be the port locally). It was failing for clortho
- fixed the `PGUSER` getting written nowhere (wrong file)
- fixed the `PGPASSWORD` value getting quoted.