### PR TITLE
Change timeouts to be unlimited. 5s (default) is way to aggressive.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       - WARDEN_STREAM=true
       - WARDEN_USE_KMS=false
       - WARDEN_DATADOG_ENABLED=false
+      - WARDEN_READ_TIMEOUT=0
+      - WARDEN_WRITE_TIMEOUT=0
     depends_on:
       - "redis"
       - "seaquill"


### PR DESCRIPTION
We have these values set to `0` everywhere. I will also change the default in Warden to `0` after we test this change.